### PR TITLE
show user pwdhash is working by coloring pw field yellow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Hashed passwords can also be generated at https://www.pwdhash.com/
 ## roadmap
 
 * make it restartless (restructure code)
+* update to build with jpm (currently built by just zipping into an XPI file)
 
 ## feature brainstorm
 

--- a/chrome/content/stanford-pwdhash.js
+++ b/chrome/content/stanford-pwdhash.js
@@ -146,7 +146,7 @@ SPH_PasswordKeyMonitor.prototype = {
     }
 
     var element = document.commandDispatcher.focusedElement;
-    if (element) { 
+    if (element) {
       if (element.nodeName == "INPUT" && element.type == "password") {
         if (element.value + lastChar == SPH_kPasswordPrefix) {
           return new SPH_PasswordProtector(element, this);
@@ -185,6 +185,7 @@ function SPH_PasswordProtector(field, monitor) {
   this.nextAvail = this.firstAvail;
   this.field = field;
   this.field.setAttribute("secure","yes");
+  this.field.setAttribute("style", "background-color: #cccc00");
   window.addEventListener("keydown", this, true);
   window.addEventListener("keyup", this, true);
   window.addEventListener("keypress", this, true);
@@ -317,7 +318,7 @@ SPH_PasswordProtector.prototype = {
       // Enforce minimum size requirement
       if(password.length < SPH_kMinimumPasswordSize) {
         var msg = SPH_strings.getString("pwdhash.shortpasswordwarn");
-        SPH_controller.warnUser(msg);  
+        SPH_controller.warnUser(msg);
         field.value = '';
         return;
       }


### PR DESCRIPTION
Does what the commit says, tested it a bit and it seemed to work. I've encountered sites that somehow intercept pwdhash and stop it from submitting the properly hashed password (possibly submitting the actual "@@masterpassword" string, which is obviously bad) - I'm not sure that this catches this, but could be a step in that direction. If nothing else, it avoids user error of thinking they're pwdhash-ing when they didn't even type @@.

One other possible future enhancement - un-coloring if the field is emptied.